### PR TITLE
Remove tracked .vscode and add ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# IDE directories
+.vscode/
+
+# Dependency directories
+node_modules/
+
+# OS generated files
+.DS_Store
+Thumbs.db
+ehthumbs.db
+*~

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "liveServer.settings.port": 5501
-}


### PR DESCRIPTION
## Summary
- remove the tracked `.vscode` editor settings
- add `.gitignore` to ignore VS Code folder, OS files and `node_modules`

The repository history still contains the `.vscode` folder because `git-filter-repo` could not be installed in the environment.

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68807da421a08322a74a1d395c6471e0