### PR TITLE
Add dark mode toggle

### DIFF
--- a/game.html
+++ b/game.html
@@ -10,10 +10,11 @@
     <div class="app-card">
         <header>
             <nav class="pelinav">
-                <a href="index.html">Etusivu</a> | 
+                <a href="index.html">Etusivu</a> |
                 <a href="rules.html">Säännöt</a>
             </nav>
             <h1>Mölkky<br/>Pisteidenlaskuri</h1>
+            <button id="themeToggle" class="theme-toggle">Tumma tila</button>
         </header>
 
         <main>
@@ -45,5 +46,6 @@
 
     <!-- JavaScript -->
     <script src="script.js"></script>
+    <script src="theme.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -331,3 +331,18 @@ footer {
 .dark-mode .pelinav a {
   color: #f0f0f0;
 }
+
+/* Dark mode toggle button */
+.theme-toggle {
+  margin-top: 0.5rem;
+  background-color: #00695c;
+  color: #fff;
+  border: none;
+  padding: 0.4rem 0.7rem;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.dark-mode .theme-toggle {
+  background-color: #4caf50;
+}

--- a/team-game.html
+++ b/team-game.html
@@ -16,6 +16,7 @@
         <a href="rules.html">Säännöt</a>
       </nav>
       <h1>Mölkky<br>Pisteidenlaskuri</h1>
+      <button id="themeToggle" class="theme-toggle">Tumma tila</button>
     </header>
 
     <div class="vuorossa-kortti">
@@ -41,5 +42,6 @@
 
 
   <script src="team-script.js"></script>
+  <script src="theme.js"></script>
 </body>
 </html>

--- a/team-style.css
+++ b/team-style.css
@@ -137,6 +137,51 @@ nav a {
   margin-top: 1rem;
 }
 
+/* Dark mode styles */
+.dark-mode {
+  background: #121212;
+  color: #f0f0f0;
+}
+
+.dark-mode .app-card {
+  background: #1e1e1e;
+  color: #f0f0f0;
+}
+
+.dark-mode header {
+  background-color: #333;
+}
+
+.dark-mode .vuorossa-kortti {
+  background: #2a2a2a;
+  border-color: #4caf50;
+}
+
+.dark-mode .controls button,
+.dark-mode .vuorossa-pisteet button {
+  background-color: #4caf50;
+}
+
+.dark-mode .controls button:hover,
+.dark-mode .vuorossa-pisteet button:hover {
+  background-color: #388e3c;
+}
+
+/* Theme toggle button */
+.theme-toggle {
+  margin-top: 0.5rem;
+  background-color: #00695c;
+  color: #fff;
+  border: none;
+  padding: 0.4rem 0.7rem;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.dark-mode .theme-toggle {
+  background-color: #4caf50;
+}
+
 .team-card {
   border-radius: 16px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggleBtn = document.getElementById('themeToggle');
+  const stored = localStorage.getItem('darkMode');
+  if (stored === 'true') {
+    document.body.classList.add('dark-mode');
+  }
+  if (toggleBtn) {
+    const updateText = () => {
+      toggleBtn.textContent = document.body.classList.contains('dark-mode') ? 'Vaalea tila' : 'Tumma tila';
+    };
+    updateText();
+    toggleBtn.addEventListener('click', () => {
+      document.body.classList.toggle('dark-mode');
+      localStorage.setItem('darkMode', document.body.classList.contains('dark-mode'));
+      updateText();
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add dark mode toggle button to individual and team games
- style and implement dark theme for both game pages
- create `theme.js` to remember preference and switch modes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6880847bf7888322bb8f791668b78503