### PR TITLE
Update grid layout for player and team cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -199,7 +199,7 @@ header {
 
 .pelaajakortit {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 0.8rem;
 }
 
@@ -297,17 +297,17 @@ header {
   .vuorossa-pisteet { flex-direction: column; gap: 0.5rem; }
   .pisteet-iso { font-size: 2rem; }
   .vuorossa-pisteet input, .vuorossa-pisteet button { width: 100%; }
-  .pelaajakortit { grid-template-columns: 1fr 1fr; gap: 0.8rem; }
+  .pelaajakortit { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.8rem; }
 }
 
 @media screen and (min-width: 501px) and (max-width: 768px) {
   .app-card { max-width: 600px; }
-  .pelaajakortit { grid-template-columns: 1fr 1fr; gap: 0.8rem; }
+  .pelaajakortit { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.8rem; }
 }
 
 @media screen and (min-width: 769px) {
   .app-card { max-width: 720px; }
-  .pelaajakortit { grid-template-columns: 1fr 1fr; gap: 0.8rem; }
+  .pelaajakortit { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.8rem; }
 }
 
 /* Navigaatiovalikko */

--- a/team-style.css
+++ b/team-style.css
@@ -132,7 +132,7 @@ nav a {
 
 #teamsContainer {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 1rem;
   margin-top: 1rem;
 }
@@ -269,6 +269,6 @@ nav a {
   }
 
   #teamsContainer {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   }
 }


### PR DESCRIPTION
## Summary
- adjust grid-template-columns for `.pelaajakortit` to auto-fit min-width 150px
- adjust grid-template-columns for `#teamsContainer` to auto-fit min-width 150px

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68809485c11083228a094532bd84eae3