### PR TITLE
Add responsive tablet & desktop styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -300,14 +300,22 @@ header {
   .pelaajakortit { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.8rem; }
 }
 
-@media screen and (min-width: 501px) and (max-width: 768px) {
-  .app-card { max-width: 600px; }
-  .pelaajakortit { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.8rem; }
+@media screen and (min-width: 601px) and (max-width: 1024px) {
+  .app-card { max-width: 700px; }
+  .vuorossa-pisteet { gap: 1rem; }
+  .pelaajakortit {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+  }
 }
 
-@media screen and (min-width: 769px) {
-  .app-card { max-width: 720px; }
-  .pelaajakortit { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.8rem; }
+@media screen and (min-width: 1025px) {
+  .app-card { max-width: 900px; }
+  .vuorossa-pisteet { gap: 1.2rem; }
+  .pelaajakortit {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.2rem;
+  }
 }
 
 /* Navigaatiovalikko */

--- a/team-style.css
+++ b/team-style.css
@@ -272,3 +272,21 @@ nav a {
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   }
 }
+
+@media (min-width: 601px) and (max-width: 1024px) {
+  .app-card { max-width: 700px; }
+  .controls { gap: 1rem; }
+  #teamsContainer {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+  }
+}
+
+@media (min-width: 1025px) {
+  .app-card { max-width: 900px; }
+  .controls { gap: 1.2rem; }
+  #teamsContainer {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- handle tablets with a 601–1024px media query
- style desktops with a 1025px+ media query

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688096cd4f388322ae5e21685ee6a77e