### PR TITLE
Add quick restart option for teams

### DIFF
--- a/team-game.html
+++ b/team-game.html
@@ -37,6 +37,7 @@
       <input type="text" id="teamNameInput" placeholder="Joukkueen nimi" />
       <button id="addTeamBtn">Lisää joukkue</button>
       <button id="startGameBtn">Aloita peli</button>
+      <button id="newRoundBtn">Uusi peli samoilla joukkueilla</button>
       <button id="resetGameBtn">Nollaa peli</button>
     </div>
   </div>

--- a/team-script.js
+++ b/team-script.js
@@ -2,6 +2,7 @@
 const teamNameInput = document.getElementById("teamNameInput");
 const addTeamBtn = document.getElementById("addTeamBtn");
 const startGameBtn = document.getElementById("startGameBtn");
+const newRoundBtn = document.getElementById("newRoundBtn");
 const resetGameBtn = document.getElementById("resetGameBtn");
 const submitScoreBtn = document.getElementById("submitScoreBtn");
 const scoreInput = document.getElementById("scoreInput");
@@ -87,6 +88,40 @@ startGameBtn.onclick = () => {
   gameStarted = true;
   updateCurrentTurn();
 };
+
+function startNewRound() {
+  if (teams.length < 2 || !teams.every(t => t.players.length > 0)) {
+    showNotification("Tarvitset vähintään kaksi joukkuetta ja pelaajat jokaiseen.");
+    return;
+  }
+  teams.forEach(team => {
+    team.score = 0;
+    team.misses = {};
+  });
+  let allPlayers = [];
+  teams.forEach((team, tIdx) => {
+    team.players.forEach(player => {
+      allPlayers.push({ teamIdx: tIdx, player });
+    });
+  });
+  let valid = false;
+  while (!valid) {
+    turnOrder = [...allPlayers].sort(() => Math.random() - 0.5);
+    valid = true;
+    for (let i = 1; i < turnOrder.length; i++) {
+      if (turnOrder[i].teamIdx === turnOrder[i - 1].teamIdx) {
+        valid = false;
+        break;
+      }
+    }
+  }
+  turnIndex = 0;
+  gameStarted = true;
+  updateCurrentTurn();
+  renderTeams();
+}
+
+newRoundBtn.onclick = startNewRound;
 
 submitScoreBtn.onclick = () => {
   if (!gameStarted) return;


### PR DESCRIPTION
## Summary
- add a button to begin a new round with the same teams
- implement `startNewRound` in team mode logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880a4b5eea48322af8a983ff5f02a38