### PR TITLE
Refactor add player handlers

### DIFF
--- a/game.html
+++ b/game.html
@@ -36,7 +36,7 @@
             <section class="toiminnot">
                 <label for="playerName">Pelaajan nimi</label>
                 <input type="text" id="playerName" placeholder="Pelaajan nimi"/>
-                <button onclick="addPlayer()">Lisää</button>
+                <button id="addPlayerBtn">Lisää</button>
                 <button onclick="arvoAloittaja()">Arvo aloittaja</button>
                 <button onclick="resetGame()">Nollaa peli</button>
             </section>

--- a/script.js
+++ b/script.js
@@ -183,4 +183,8 @@ document.addEventListener("DOMContentLoaded", () => {
   if (nappi) {
     nappi.addEventListener("click", lisaaPisteetVuorossa);
   }
+  const addBtn = document.getElementById("addPlayerBtn");
+  if (addBtn) {
+    addBtn.addEventListener("click", addPlayer);
+  }
 });

--- a/team-script.js
+++ b/team-script.js
@@ -47,20 +47,26 @@ function renderTeams() {
       </ul>
       <label for="player-${index}">Pelaajan nimi</label>
       <input type="text" id="player-${index}" placeholder="Pelaajan nimi" />
-      <button class="add-player-btn" onclick="addPlayer(${index})">Lisää pelaaja</button>
     `;
+    const button = document.createElement("button");
+    button.className = "add-player-btn";
+    button.textContent = "Lisää pelaaja";
+    button.dataset.teamIndex = index;
+    button.addEventListener("click", handleAddPlayer);
+    card.appendChild(button);
     teamsContainer.appendChild(card);
   });
 }
 
-window.addPlayer = (teamIndex) => {
+function handleAddPlayer(e) {
+  const teamIndex = +e.currentTarget.dataset.teamIndex;
   const input = document.getElementById(`player-${teamIndex}`);
   const name = input.value.trim();
   if (!name) return;
   teams[teamIndex].players.push(name);
   input.value = "";
   renderTeams();
-};
+}
 
 startGameBtn.onclick = () => {
   if (teams.length < 2 || !teams.every(t => t.players.length > 0)) {


### PR DESCRIPTION
## Summary
- switch team player add buttons to DOM listeners
- add `handleAddPlayer` helper
- remove inline add button for single game
- wire up add player button in single game script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880ac73e4908322b082d7e34fc0e52c