### PR TITLE
Center win notification

### DIFF
--- a/style.css
+++ b/style.css
@@ -289,6 +289,11 @@ header {
   transform: translateX(-50%) scale(1.02);
 }
 
+#notification.center {
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
 /* Responsiivisuus */
 
 @media screen and (max-width: 500px) {

--- a/team-script.js
+++ b/team-script.js
@@ -10,10 +10,16 @@ const currentTurnDisplay = document.getElementById("currentTurn");
 const teamsContainer = document.getElementById("teamsContainer");
 const notification = document.getElementById("notification");
 
-function showNotification(message) {
+function showNotification(message, center = false) {
   notification.textContent = message;
   notification.classList.remove("hidden");
-  setTimeout(() => notification.classList.add("hidden"), 3000);
+  notification.classList.add("visible");
+  if (center) notification.classList.add("center");
+  setTimeout(() => {
+    notification.classList.remove("visible");
+    notification.classList.add("hidden");
+    if (center) notification.classList.remove("center");
+  }, 3000);
 }
 
 let teams = [];
@@ -166,7 +172,7 @@ submitScoreBtn.onclick = () => {
       team.score = 25;
       showNotification(`${team.name} ylitti 50 pistettä! Pisteet palautettiin 25:een.`);
     } else if (team.score === 50) {
-      showNotification(`${team.name} voittaa pelin!`);
+      showNotification(`${team.name} voittaa pelin!`, true);
       gameStarted = false;
       return;
     }


### PR DESCRIPTION
## Summary
- enhance team notifications with visible/center classes
- center the win message and show it using the updated function
- add new CSS rule to handle centered notification display

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6880b91c5774832285fe3a9b67e82a3c